### PR TITLE
Responsive Site, Primary Colors, and more

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -6,7 +6,7 @@
     <title>Svelte Society - Chicago</title>
     <link rel="icon" href="/svelte_chicago_125x125.png" />
 </svelte:head>
-<div class="fixed top-0 right-0 rounded-l-full  text-xl flex flex-row justify-end align-baseline bg-red-600 z-10 text-white">
+<div class="fixed top-0 right-0 rounded-l-full  text-xl flex flex-row justify-end align-baseline bg-primary z-10 text-white">
     <div class="pl-8" />
     <div class="p-2">
         <a href="/events">Events</a>

--- a/src/routes/events.svelte
+++ b/src/routes/events.svelte
@@ -42,7 +42,7 @@
                 <td>{ev.data().Date.toDate()}</td>
                 <td>{ev.data().Location}</td>
                 <td>{ev.data().Description}</td>
-                <td class="text-center"><a href="/event/{ev.id}" class="text-red-600"><Icon data={calendar} /></a></td>
+                <td class="text-center"><a href="/event/{ev.id}" class="text-primary"><Icon data={calendar} /></a></td>
                 </tr>
             {/each}
         {:catch error}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,29 +1,41 @@
 <script>
     import Icon from 'svelte-awesome';
     import { twitter, github } from 'svelte-awesome/icons';
+
+    const socials = [{
+        icon: twitter,
+        url: 'https://twitter.com/SvelteChicago'
+    },{
+        icon: github,
+        url: 'https://github.com/svelte-chicago/'
+    }]
 </script>
 
 
-<div class='w-full relative max-w-4xl h-screen text-center border-red-600 border-l-2 border-r-2'>
+<div class='w-full relative max-w-4xl h-full min-h-screen text-center border-primary border-l-2 border-r-2'>
+    <!-- Chicago Flag -->
     <img src="/chicago_flag.svg" class='w-full' alt="Flag of the City of Chicago"/>
-    <div class="absolute bottom-[30%] left-6 align-middle ">
-        <div class="border-red-600 lg:h-[10rem] lg:w-[10rem] sm:h-[7rem] sm:w-[7rem] bg-white border-8 rounded-full p-4 align-middle inline-block">
+
+    <!-- Logo and images -->
+    <div class="flex items-center justify-start gap-x-4 ml-8 lg:ml-24 -mt-4 lg:-mt-48">
+        <div class="border-primary lg:h-[10rem] lg:w-[10rem] h-28 w-28 bg-white border-8 rounded-full p-4 aspect-square">
             <img src="/svelte_chicago_125x125.png" alt="Svelte Society Chicago Logo" />
         </div>
-        <div class="text-red-600 g:h-[10rem] lg:w-[10rem] sm:h-[7rem] sm:w-[7rem] pt-6 inline-block rounded-full align-middle pl-6">
-            <a href="https://twitter.com/SvelteChicago" target="_new"><Icon data={twitter} scale="4" class="bg-white w-full h-full border-2 border-red-600 rounded-full" /></a>
-        </div>
-        <div class="text-red-600 g:h-[10rem] lg:w-[10rem] sm:h-[7rem] sm:w-[7rem] pt-6 inline-block rounded-full align-middle pl-6 ">
-            <a href="https://github.com/svelte-chicago/" target="_new"><Icon data={github} scale="4" class="bg-white w-full h-full border-2 border-red-600 rounded-full" /></a>
-        </div>
+        {#each socials as {url, icon} (url)}
+            <div class="text-primary lg:w-36 h-20 w-20 rounded-full">
+                <a href="{url}" target="_new"><Icon data={icon} scale="4" class="bg-white w-full h-full border-2 p-2 lg:p-0 border-primary rounded-full aspect-square" /></a>
+            </div>
+        {/each}
     </div>
-    <div class='absolute bottom-[8rem] left-[8rem] text-left'>
-        <div class="text-4xl">
+    
+    <!-- Body Text -->
+    <div class='text-left px-8 md:px-32 mt-12'>
+        <div class="text-4xl mb-3">
             Svelte Society: Chicago
         </div>
-        <div class="text-xl">
-            We're just getting started - find us on twitter and github or
-            join us at an <a href="/events" class="text-red-600 underline">event</a>
+        <div class="text-xl pb-8">
+            We're just getting started - find us on Twitter and GitHub or
+            join us at an <a href="/events" class="text-primary underline">event</a>
         </div>
     </div>
 </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,7 +1,13 @@
 module.exports = {
   content: ['./src/**/*.{html,js,svelte}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        // From https://www.flagcolorcodes.com/chicago
+        'primary': '#FF0000',
+        'secondary': '#B3DDF2'
+      }
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
**Svelte Society: Chicago** is awesome 😎

This PR introduces a few quick changes to the site.
1. Add Responsive Design
2. Add colors to `tailwind.config.js`
3. Fix some CSS issues

## Add responsive design

| Before      | After |
| ----------- | ----------- |
| <img width="688" alt="Screen Shot 2022-04-30 at 11 11 01 PM" src="https://user-images.githubusercontent.com/46694203/166130741-1e6b5dfa-6cee-4613-b5c8-46016e1ba172.png">      | <img width="686" alt="Screen Shot 2022-04-30 at 11 11 06 PM" src="https://user-images.githubusercontent.com/46694203/166130742-a1d7974a-41b6-4f61-b604-eb92296ddcc2.png">       |

## Add colors to `tailwind.config.js`

Previously, the primary Chicago red was using the tailwind `red-600` color. From ([apparently](https://www.flagcolorcodes.com/chicago)) Chicago's official color palette, this PR adds the `primary` color to the config. This PR also adds the `secondary` color.

You'll notice the color is a bit different than before — of course, it can be changed to the old one, but I think leaving it as the `primary` color is a good idea. If you liked the old color better, for the record, its hex code is [`#dc2626`](https://tailwindcss.com/docs/customizing-colors)

## Fix some CSS issues

There were a couple quick changes I made to the CSS to make it more readable and parsable. Tailwind makes it easy!